### PR TITLE
as "¶" is non-ascii character, we need to define encoding.

### DIFF
--- a/src/profiles/admin.py
+++ b/src/profiles/admin.py
@@ -1,3 +1,4 @@
+# -*- coding: iso-8859-15 -*-
 from django.contrib import admin
 from authtools.admin import NamedUserAdmin
 from .models import Profile


### PR DESCRIPTION
django/python takes output as ASCII by default, we need to define another (iso-8859) encoding for this piece of code as ¶ is a non-ascii character.