### PR TITLE
Switch django-debug-toolbar to dev requirements file

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,6 +3,5 @@ django-environ>=0.3.0
 django-braces>=1.4.0
 django-crispy-forms>=1.4.0
 django-admin-bootstrapped>=1.6.9
-django-debug-toolbar>=1.2.1
 django-authtools>=1.0.0
 easy-thumbnails>=2.2

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -2,3 +2,4 @@
 
 # Extra stuff required for local dev
 pudb==2014.1
+django-debug-toolbar>=1.2.1


### PR DESCRIPTION
Hi Arun,

django-debug-toolbar is an important dev tool, maybe your place is in `requirements/development.txt` file.