### PR TITLE
Fix for the TEMPLATE_* backwards compatibility for 1.8

### DIFF
--- a/src/project_name/settings/development.py
+++ b/src/project_name/settings/development.py
@@ -4,8 +4,7 @@ import logging.config
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
-TEMPLATE_DEBUG = True
-
+TEMPLATES[0]['OPTIONS'].update({'debug': True})
 # Turn off debug while imported by Celery with a workaround
 # See http://stackoverflow.com/a/4806384
 if "celery" in sys.argv[0]:


### PR DESCRIPTION
    ?: (1_8.W001) The standalone TEMPLATE_* settings were deprecated in Django
    1.8 and the TEMPLATES dictionary takes precedence. You must put the values
    of the following settings into your default TEMPLATES dict: TEMPLATE_DEBUG.

https://docs.djangoproject.com/en/1.8/ref/checks/#backwards-compatibility
https://docs.djangoproject.com/en/1.8/ref/templates/upgrading/#the-templates-settings