### PR TITLE
moving loading of local.env to manage.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,4 @@ Thumbs.db
 Desktop.ini
 
 # Project settings
-./site/
+/site/

--- a/src/manage.py
+++ b/src/manage.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python
+from os.path import dirname, join, exists
 import os
 import sys
+
+import environ
+
+env = environ.Env()
+env_file = join(dirname(__file__), '{{ project_name }}/settings/' 'local.env')
+if exists(env_file):
+    environ.Env.read_env(str(env_file))
 
 if __name__ == "__main__":
     # CHANGED manage.py will use development settings by

--- a/src/project_name/settings/base.py
+++ b/src/project_name/settings/base.py
@@ -7,8 +7,12 @@ https://docs.djangoproject.com/en/dev/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/dev/ref/settings/
 """
+from os.path import dirname, join
+
+from django.contrib import messages
 from django.core.urlresolvers import reverse_lazy
-from os.path import dirname, join, exists
+import environ
+
 
 # Build paths inside the project like this: join(BASE_DIR, "directory")
 BASE_DIR = dirname(dirname(dirname(__file__)))
@@ -42,14 +46,7 @@ TEMPLATES = [
 ]
 
 # Use 12factor inspired environment variables or from a file
-import environ
 env = environ.Env()
-
-# Ideally move env file should be outside the git repo
-# i.e. BASE_DIR.parent.parent
-env_file = join(dirname(__file__), 'local.env')
-if exists(env_file):
-    environ.Env.read_env(str(env_file))
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/dev/howto/deployment/checklist/
@@ -127,7 +124,6 @@ ALLOWED_HOSTS = []
 CRISPY_TEMPLATE_PACK = 'bootstrap3'
 
 # For Bootstrap 3, change error alert to 'danger'
-from django.contrib import messages
 MESSAGE_TAGS = {
     messages.ERROR: 'danger'
 }

--- a/src/project_name/wsgi.py
+++ b/src/project_name/wsgi.py
@@ -13,12 +13,13 @@ from django.conf import settings
 from django.core.wsgi import get_wsgi_application
 import environ
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings.production")
-application = get_wsgi_application()
 
 env = environ.Env()
 env_file = join(dirname(__file__), 'settings/' 'local.env')
 if exists(env_file):
     environ.Env.read_env(str(env_file))
+
+application = get_wsgi_application()
 
 # Wrap werkzeug debugger if DEBUG is on
 if settings.DEBUG:

--- a/src/project_name/wsgi.py
+++ b/src/project_name/wsgi.py
@@ -6,14 +6,21 @@ It exposes the WSGI callable as a module-level variable named ``application``.
 For more information on this file, see
 https://docs.djangoproject.com/en/dev/howto/deployment/wsgi/
 """
+from os.path import dirname, join, exists
 import os
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings.production")
 
+from django.conf import settings
 from django.core.wsgi import get_wsgi_application
+import environ
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings.production")
 application = get_wsgi_application()
 
+env = environ.Env()
+env_file = join(dirname(__file__), 'settings/' 'local.env')
+if exists(env_file):
+    environ.Env.read_env(str(env_file))
+
 # Wrap werkzeug debugger if DEBUG is on
-from django.conf import settings
 if settings.DEBUG:
     try:
         import django.views.debug


### PR DESCRIPTION
So here's what was happening. New Django project from latest edge. 

when deploying to the server because manage.py was looking for an ENV var to define the settings location without ever loading the local.env it was always looking for the development settings because that's what was defaulted in manage.py

subsequently this applied to wsgi.py which was defaulting to production. If a users local.env ever called for a different settings file it would not be loaded.

Moving the loading of the local.env file into the environment at the manage.py and wsgi.py levels means that it is no longer needed in settings.base
