### PR TITLE
the DubugToolbar was needed in Middleware classes

### DIFF
--- a/src/project_name/settings/base.py
+++ b/src/project_name/settings/base.py
@@ -88,6 +88,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
 )
 
 ROOT_URLCONF = '{{ project_name }}.urls'


### PR DESCRIPTION
This middelware line was needed to get past an error in the instructions given in the read the docs.