### PR TITLE
Corrected message after password change

### DIFF
--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -57,8 +57,7 @@ class PasswordChangeView(authviews.PasswordChangeView):
     def form_valid(self, form):
         form.save()
         messages.success(self.request,
-                         "Your password was changed, "
-                         "hence you have been logged out. Please relogin")
+                         "Your password has been changed successfully")
         return super(PasswordChangeView, self).form_valid(form)
 
 


### PR DESCRIPTION
If you change your password, you got the message

> Your password was changed, hence you have been logged out. Please
> relogin

However you're NOT logged out. This is also in line with what is
described in django-authtools:
https://github.com/fusionbox/django-authtools/blob/fa820681230b30bf3656f0e9294f3910af9869b3/authtools/views.py#L252

So I updated the message to read "Your password has been changed
successfully"